### PR TITLE
Account for new LemmyErrorType

### DIFF
--- a/src/models/schemaProperties.ts
+++ b/src/models/schemaProperties.ts
@@ -9,5 +9,6 @@ export interface SchemaProperties {
             type?: string;
         }
         $ref?: string;
+        enum?: string[];
     };
 }

--- a/src/properties/handleProperty.ts
+++ b/src/properties/handleProperty.ts
@@ -40,6 +40,13 @@ export function handleProperty(name: string, type: Type, schema: Schema, isOptio
                 $ref: `#/components/schemas/${type.getSymbol()?.getName() ?? type.getAliasSymbol()?.getName()}`
             }
         }
+    } else if (type.isLiteral()) {
+        schema.properties[name] = {
+            type: "string",
+            enum: [
+                type.getText()
+            ],
+        }
     } else {
         if (isReferenceType(type, typeRegistry)) {
             schema.properties[name] = {


### PR DESCRIPTION
This PR is supposed to account for new [LemmyErrorType](https://github.com/LemmyNet/lemmy-js-client/commit/b5355233fd90ec1539f285834b7f2e0864e57595#diff-5230e5a27e882ba2878edf7770f8c5424c93111c5ac215778379036c9ffe46e3) which was recently added to the lemmy-js-client.

The new type is a union type of object literals, which is basically a glorified enum. The only way (known to me) to have this in the OpenAPI spec is to have an object structured like this:

```JSON       
{
  "type": "object",
  "required": [
    "error_type",
    "message"
  ],
  "properties": {
    "error_type": {
      "type": "string",
      "enum": [
        "\"PictrsPurgeResponseError\""
      ]
    },
    "message": {
      "type": "string",
      "nullable": false
    }
  }
}
```

I'm also not a typescript developer, so I don't really know if the only thing we have to check for is if the object is literal.