### PR TITLE
Generate all HTTP methods for paths which have more than one HTTP method

### DIFF
--- a/src/paths/processPaths.ts
+++ b/src/paths/processPaths.ts
@@ -94,8 +94,10 @@ export function processPaths(sourceFile: SourceFile, typeRegistry: {
         })
 
         if (httpMethod === "post" || httpMethod === "put") {
-            paths[path] = {
-                [httpMethod]: {
+            // Check if paths[path] already exists
+            if (paths.hasOwnProperty(path)) {
+                // If it exists just add the new http method
+                paths[path][httpMethod] = {
                     operationId,
                     requestBody: {
                         content: {
@@ -115,15 +117,46 @@ export function processPaths(sourceFile: SourceFile, typeRegistry: {
                         },
                     },
                     summary: summary,
-                },
-            };
+                }; 
+            } else {
+                // If paths[path] does not exist, create a new entry for it
+                paths[path] = {
+                    [httpMethod]: {
+                        operationId,
+                        requestBody: {
+                            content: {
+                                "application/json": {
+                                    schema: createSchemaRef(paramType)
+                                }
+                            }
+                        },
+                        responses: {
+                            '200': {
+                                description: 'OK',
+                                content: {
+                                    'application/json': {
+                                        schema: createSchemaRef(returnType),
+                                    },
+                                },
+                            },
+                        },
+                        summary: summary,
+                    },
+                };
+            }
         } else {
-
-            // Create a path item for this method
-            paths[path] = {
-                [httpMethod]: {
+            // Check if paths[path] already exists
+            if (paths.hasOwnProperty(path)) {
+                // If it exists just add the new http method
+                paths[path][httpMethod] = {
                     operationId,
-                    parameters: pathParams,
+                    requestBody: {
+                        content: {
+                            "application/json": {
+                                schema: createSchemaRef(paramType)
+                            }
+                        }
+                    },
                     responses: {
                         '200': {
                             description: 'OK',
@@ -134,9 +167,34 @@ export function processPaths(sourceFile: SourceFile, typeRegistry: {
                             },
                         },
                     },
-                    summary: summary,
-                },
-            };
+                    summary: summary
+                };
+            } else {
+                // If paths[path] does not exist, create a new entry for it
+                paths[path] = {
+                    [httpMethod]: {
+                        operationId,
+                        requestBody: {
+                            content: {
+                                "application/json": {
+                                    schema: createSchemaRef(paramType)
+                                }
+                            }
+                        },
+                        responses: {
+                            '200': {
+                                description: 'OK',
+                                content: {
+                                    'application/json': {
+                                        schema: createSchemaRef(returnType),
+                                    },
+                                },
+                            },
+                        },
+                        summary: summary,
+                    },
+                };
+            }
         }
     }
 

--- a/src/paths/processPaths.ts
+++ b/src/paths/processPaths.ts
@@ -150,13 +150,7 @@ export function processPaths(sourceFile: SourceFile, typeRegistry: {
                 // If it exists just add the new http method
                 paths[path][httpMethod] = {
                     operationId,
-                    requestBody: {
-                        content: {
-                            "application/json": {
-                                schema: createSchemaRef(paramType)
-                            }
-                        }
-                    },
+                    parameters: pathParams,
                     responses: {
                         '200': {
                             description: 'OK',
@@ -174,13 +168,7 @@ export function processPaths(sourceFile: SourceFile, typeRegistry: {
                 paths[path] = {
                     [httpMethod]: {
                         operationId,
-                        requestBody: {
-                            content: {
-                                "application/json": {
-                                    schema: createSchemaRef(paramType)
-                                }
-                            }
-                        },
+                        parameters: pathParams,
                         responses: {
                             '200': {
                                 description: 'OK',


### PR DESCRIPTION
Currently all the generated paths which have more than one HTTP method were not generated. For example path "/comment" has POST, PUT and GET. On every path with the same name the generator did overwrite it with the latest entry. Again with "/comment" the only generated method was GET because it was last. This should fix it.